### PR TITLE
Remove dependency on `unstable/socket`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,6 @@
 #lang setup/infotab
 
 (define collection 'multi)
-(define deps '("base" "scribble-lib" "xdr" "tandem" "misc1" "xexpr-path"))
+(define deps '("base" "scribble-lib" "xdr" "tandem" "misc1" "xexpr-path" "unix-socket-lib"))
 
 ; vim:set ts=2 sw=2 et:

--- a/libvirt/private/protocol.rkt
+++ b/libvirt/private/protocol.rkt
@@ -5,7 +5,7 @@
 
 (require racket/contract
          racket/generator
-         unstable/socket
+         racket/unix-socket
          racket/format
          racket/match
          racket/tcp)


### PR DESCRIPTION
The functionality of that library has been moved to `racket/unix-socket` (package `unix-socket-lib`), and `unstable/socket` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2.1. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-lib` package, as it will not be part of the main distribution in future versions. If you decide to go with that option, please add a dependency to `unstable-lib`.
